### PR TITLE
Slurmctld dependency

### DIFF
--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -18,17 +18,17 @@ os.environ['LD_LIBRARY_PATH'] = LD_LIBRARY_PATH
 
 SNAP_MODE_PROCESS_MAP = {
     "slurmdbd": ["munged", "slurmdbd", "mysql"],
+    "slurmctld": ["munged", "slurmctld"],
     "slurmd": ["munged", "slurmd"],
     "slurmrestd": ["munged", "slurmrestd"],
-    "slurmctld": ["munged", "slurmctld"],
     "login": [],
     "all": [
         "munged",
         "mysql",
         "slurmdbd",
+        "slurmctld",
         "slurmd",
         "slurmrestd",
-        "slurmctld",
     ],
     "none": [],
 }

--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -18,17 +18,17 @@ os.environ['LD_LIBRARY_PATH'] = LD_LIBRARY_PATH
 
 SNAP_MODE_PROCESS_MAP = {
     "slurmdbd": ["munged", "slurmdbd", "mysql"],
-    "slurmctld": ["munged", "slurmctld"],
     "slurmd": ["munged", "slurmd"],
     "slurmrestd": ["munged", "slurmrestd"],
+    "slurmctld": ["munged", "slurmctld"],
     "login": [],
     "all": [
         "munged",
         "mysql",
         "slurmdbd",
-        "slurmctld",
         "slurmd",
         "slurmrestd",
+        "slurmctld",
     ],
     "none": [],
 }

--- a/src/slurm-bins/bin/slurmctld
+++ b/src/slurm-bins/bin/slurmctld
@@ -21,7 +21,7 @@ if [[ $snap_mode = "all" ]]; then
 
     while ! [[ -f $SLURMD_INIT ]]
     do
-        pprint "Waiting for SLURMDBD to initialize";
+        pprint "Waiting for SLURMD to initialize";
 	sleep 1
     done
 fi
@@ -35,6 +35,7 @@ else
     touch $SNAP_COMMON/etc/slurm-snap-init-utils/slurmctld-init-complete
 fi
 
+sleep 10
 
 pprint "Starting SLURMCTLD";
 exec "$SNAP/slurm-bins/slurmctld" \

--- a/src/slurm-bins/bin/slurmctld
+++ b/src/slurm-bins/bin/slurmctld
@@ -22,10 +22,9 @@ if [[ $snap_mode = "all" ]]; then
     while ! [[ -f $SLURMD_INIT ]]
     do
         pprint "Waiting for SLURMD to initialize";
-	sleep 1
+	sleep 5
     done
 fi
-
 
 # Start slurmctld only if we have a config file
 if ! [[ -f $SLURM_CONF ]]; then
@@ -34,8 +33,6 @@ if ! [[ -f $SLURM_CONF ]]; then
 else
     touch $SNAP_COMMON/etc/slurm-snap-init-utils/slurmctld-init-complete
 fi
-
-sleep 10
 
 pprint "Starting SLURMCTLD";
 exec "$SNAP/slurm-bins/slurmctld" \

--- a/src/slurm-bins/bin/slurmctld
+++ b/src/slurm-bins/bin/slurmctld
@@ -13,13 +13,14 @@ fi
 . "$SNAP/utilities/common-utilities"
 export SLURM_CONF=$SNAP_COMMON/etc/slurm/slurm.conf
 export SLURMCTLD_LOG=$SNAP_COMMON/var/log/slurm/slurmctld.log
+export SLURMD_LOG=$SNAP_COMMON/var/log/slurm/slurmd.log
 export SLURMD_INIT=$SNAP_COMMON/etc/slurm-snap-init-utils/slurmd-init-complete
 export LD_LIBRARY_PATH=$SNAP/usr/lib/:$SNAP/usr/lib/x86_64-linux-gnu/:$SNAP/lib/slurm/:$SNAP/usr/local/lib/:$SNAP/lib/x86_64-linux-gnu/:$SNAP/lib/
 
 # Wait for slurmdbd if snap.mode="all"
 if [[ $snap_mode = "all" ]]; then
 
-    while ! [[ -f $SLURMD_INIT ]]
+    while ! [[ -f $SLURMD_LOG ]]
     do
         pprint "Waiting for SLURMD to initialize";
 	sleep 5

--- a/src/slurm-bins/bin/slurmctld
+++ b/src/slurm-bins/bin/slurmctld
@@ -13,14 +13,13 @@ fi
 . "$SNAP/utilities/common-utilities"
 export SLURM_CONF=$SNAP_COMMON/etc/slurm/slurm.conf
 export SLURMCTLD_LOG=$SNAP_COMMON/var/log/slurm/slurmctld.log
-export SLURMDBD_INIT=$SNAP_COMMON/etc/slurm-snap-init-utils/slurmdbd-init-complete
+export SLURMD_INIT=$SNAP_COMMON/etc/slurm-snap-init-utils/slurmd-init-complete
 export LD_LIBRARY_PATH=$SNAP/usr/lib/:$SNAP/usr/lib/x86_64-linux-gnu/:$SNAP/lib/slurm/:$SNAP/usr/local/lib/:$SNAP/lib/x86_64-linux-gnu/:$SNAP/lib/
-
 
 # Wait for slurmdbd if snap.mode="all"
 if [[ $snap_mode = "all" ]]; then
 
-    while ! [[ -f $SLURMDBD_INIT ]]
+    while ! [[ -f $SLURMD_INIT ]]
     do
         pprint "Waiting for SLURMDBD to initialize";
 	sleep 1

--- a/src/slurm-bins/bin/slurmd
+++ b/src/slurm-bins/bin/slurmd
@@ -13,18 +13,19 @@ fi
 . "$SNAP/utilities/common-utilities"
 export SLURM_CONF=$SNAP_COMMON/etc/slurm/slurm.conf
 export SLURMD_LOG=$SNAP_COMMON/var/log/slurm/slurmd.log
-export SLURMCTLD_INIT=$SNAP_COMMON/etc/slurm-snap-init-utils/slurmctld-init-complete
+# export SLURMCTLD_INIT=$SNAP_COMMON/etc/slurm-snap-init-utils/slurmctld-init-complete
+export SLURMDBD_INIT=$SNAP_COMMON/etc/slurm-snap-init-utils/slurmdbd-init-complete
 export LD_LIBRARY_PATH=$SNAP/usr/lib/:$SNAP/usr/lib/x86_64-linux-gnu/:$SNAP/lib/slurm/:$SNAP/usr/local/lib/:$SNAP/lib/x86_64-linux-gnu/:$SNAP/lib/
 
-
-# Wait for slurmctld if snap.mode="all"
+# Wait for slurmdbd if snap.mode="all"
 if [[ $snap_mode = "all" ]]; then
 
-    while ! [[ -f $SLURMCTLD_INIT ]]
+    while ! [[ -f $SLURMDBD_INIT ]]
     do
-        pprint "Waiting for SLURMCTLD to initialize";
+        pprint "Waiting for SLURMDBD to initialize";
 	sleep 1
     done
+
 fi
 
 
@@ -32,6 +33,8 @@ fi
 if ! [[ -f $SLURM_CONF ]]; then
     pprint "No slurm conf, cannot start process.";
     exit -1
+else
+        touch $SNAP_COMMON/etc/slurm-snap-init-utils/slurmd-init-complete
 fi
 
 pprint "Starting SLURMD";

--- a/src/slurm-bins/bin/slurmd
+++ b/src/slurm-bins/bin/slurmd
@@ -28,13 +28,12 @@ if [[ $snap_mode = "all" ]]; then
 
 fi
 
-
 # Start slurmd only if we have a config file
 if ! [[ -f $SLURM_CONF ]]; then
     pprint "No slurm conf, cannot start process.";
     exit -1
 else
-        touch $SNAP_COMMON/etc/slurm-snap-init-utils/slurmd-init-complete
+    touch $SNAP_COMMON/etc/slurm-snap-init-utils/slurmd-init-complete
 fi
 
 pprint "Starting SLURMD";


### PR DESCRIPTION
New dependency chain:

1) Slurmd waits for Slurmdbd
2) Slurmctl waits for Slurmd

The mechanism for Slurmctld is the Slurmd log file, which does not exist until Slurmd is full up and operational. This will efficiently eliminate any race conditions with Slurmctld on Slurmd