### PR TITLE
Configless v0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.snap
+*.resource
 .terraform
 terraform*
 .tox/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,22 +25,22 @@ apps:
   slurmdbd:
     command: bin/slurmdbd
     daemon: simple
-    restart-condition: on-failure
+    restart-condition: never
 
   slurmctld:
     command: bin/slurmctld
     daemon: simple
-    restart-condition: on-failure
+    restart-condition: never
 
   slurmd:
     command: bin/slurmd
     daemon: simple
-    restart-condition: on-failure
+    restart-condition: never
 
   slurmrestd:
     command: bin/slurmrestd
     daemon: simple
-    restart-condition: on-failure
+    restart-condition: never
 
   sacct:
     command: bin/sacct

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -113,7 +113,7 @@ parts:
       - http-parser
       - munge
     plugin: dump
-    source: https://download.schedmd.com/slurm/slurm-20.02.1.tar.bz2
+    source: https://download.schedmd.com/slurm/slurm-20.11.3.tar.bz2
     build-packages:
       - libhdf5-dev
       - python-dev

--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -174,6 +174,13 @@ def render_slurm_conf():
     return f.read_text().format(**ctxt)
 
 
+def configure_slurmctld_hostname(slurmctld_hostname):
+    """Write the slurmctld hostname to SNAP_COMMON."""
+    if slurmctld_hostname:
+        snap_common = Path(f"{os.environ['SNAP_COMMON']}")
+        (snap_common / "slurmctld_hostname").write_text(slurmctld_hostname)
+
+
 def configure_snap_mode_and_render_slurm_config(snap_mode_from_snap_config):
     snap_mode_path = Path(f"{os.environ['SNAP_COMMON']}/snap_mode")
 
@@ -198,10 +205,12 @@ def configure_snap_mode_and_render_slurm_config(snap_mode_from_snap_config):
 if __name__ == "__main__":
     snap_mode = snapctl_get("snap.mode")
     munge_key = snapctl_get("munge.key")
+    slurmctld_hostname = snapctl_get("slurmctld.hostname")
 
     stop_all_daemons()
 
     configure_munge(munge_key)
     configure_snap_mode_and_render_slurm_config(snap_mode)
+    configure_slurmctld_hostname(slurmctld_hostname)
 
     daemon_starter(snap_mode)

--- a/src/hooks/bin/configure
+++ b/src/hooks/bin/configure
@@ -4,6 +4,7 @@ import os
 import sys
 import socket
 import subprocess
+from base64 import b64decode, b64encode
 from pathlib import Path
 
 
@@ -70,9 +71,12 @@ def configure_munge(munge_key_from_snap_config):
     # If the munge key in $SNAP_COMMON/etc/munge/munge.key and the key
     # obtained from snapctl get are identical, return.
     if munge_key_path.exists() and munge_key_from_snap_config is not None:
-        if munge_key_path.read_text() != munge_key_from_snap_config:
+        munge_key_str = b64encode(munge_key_path.read_bytes()).decode()
+        if munge_key_str != munge_key_from_snap_config:
+            munge_key_path.write_bytes(
+                b64decode(munge_key_from_snap_config.encode())
+            )
             munge_key_path.chmod(0o700)
-            munge_key_path.write_text(munge_key_from_snap_config)
         else:
             return
     # If the munge.key is not defined as a snap config AND the
@@ -84,7 +88,9 @@ def configure_munge(munge_key_from_snap_config):
     # write the snap munge.key config to the munge key file.
     elif not munge_key_path.exists() and \
             munge_key_from_snap_config is not None:
-        munge_key_path.write_text(munge_key_from_snap_config)
+        munge_key_path.write_bytes(
+            b64decode(munge_key_from_snap_config.encode())
+        )
     else:
         return
 
@@ -169,7 +175,10 @@ def render_slurm_conf():
         "Default=YES State=UP"
     )
 
-    # Load, merge and render the template and ctxt into the slurmdbd.conf.
+    if Path(f"{os.environ['SNAP_COMMON']}/slurmctld_hostname").exists():
+        ctxt['SlurmctldParameters'] = "enable_configless"
+
+    # Render the template.
     f = slurm_configurator_templates_base_path / "slurm.conf.tmpl"
     return f.read_text().format(**ctxt)
 
@@ -198,8 +207,9 @@ def configure_snap_mode_and_render_slurm_config(snap_mode_from_snap_config):
     slurm_conf_file = Path(
         f"{os.environ['SNAP_COMMON']}/etc/slurm/slurm.conf"
     )
-    slurm_conf_file.write_text(render_slurm_conf())
-    slurm_conf_file.chmod(0o777)
+    if snap_mode_from_snap_config == "all":
+        slurm_conf_file.write_text(render_slurm_conf())
+        slurm_conf_file.chmod(0o777)
 
 
 if __name__ == "__main__":
@@ -210,7 +220,7 @@ if __name__ == "__main__":
     stop_all_daemons()
 
     configure_munge(munge_key)
-    configure_snap_mode_and_render_slurm_config(snap_mode)
     configure_slurmctld_hostname(slurmctld_hostname)
+    configure_snap_mode_and_render_slurm_config(snap_mode)
 
     daemon_starter(snap_mode)

--- a/src/slurm-bins/bin/slurmctld
+++ b/src/slurm-bins/bin/slurmctld
@@ -13,20 +13,20 @@ fi
 . "$SNAP/utilities/common-utilities"
 export SLURM_CONF=$SNAP_COMMON/etc/slurm/slurm.conf
 export SLURMCTLD_LOG=$SNAP_COMMON/var/log/slurm/slurmctld.log
-export SLURMD_LOG=$SNAP_COMMON/var/log/slurm/slurmd.log
+#export SLURMD_LOG=$SNAP_COMMON/var/log/slurm/slurmd.log
 export SLURMD_INIT=$SNAP_COMMON/etc/slurm-snap-init-utils/slurmd-init-complete
 
 # Wait for slurmdbd if snap.mode="all"
-if [[ $snap_mode = "all" ]]; then
+#if [[ $snap_mode = "all" ]]; then
+#
+#    while ! [[ -f $SLURMD_LOG ]]
+#    do
+#        pprint "Waiting for SLURMD to initialize";
+#	sleep 5
+#    done
 
-    while ! [[ -f $SLURMD_LOG ]]
-    do
-        pprint "Waiting for SLURMD to initialize";
-	sleep 5
-    done
-
-    sleep 5
-fi
+#    sleep 5
+#fi
 
 # Start slurmctld only if we have a config file
 if ! [[ -f $SLURM_CONF ]]; then

--- a/src/slurm-bins/bin/slurmctld
+++ b/src/slurm-bins/bin/slurmctld
@@ -13,20 +13,8 @@ fi
 . "$SNAP/utilities/common-utilities"
 export SLURM_CONF=$SNAP_COMMON/etc/slurm/slurm.conf
 export SLURMCTLD_LOG=$SNAP_COMMON/var/log/slurm/slurmctld.log
-#export SLURMD_LOG=$SNAP_COMMON/var/log/slurm/slurmd.log
 export SLURMD_INIT=$SNAP_COMMON/etc/slurm-snap-init-utils/slurmd-init-complete
 
-# Wait for slurmdbd if snap.mode="all"
-#if [[ $snap_mode = "all" ]]; then
-#
-#    while ! [[ -f $SLURMD_LOG ]]
-#    do
-#        pprint "Waiting for SLURMD to initialize";
-#	sleep 5
-#    done
-
-#    sleep 5
-#fi
 
 # Start slurmctld only if we have a config file
 if ! [[ -f $SLURM_CONF ]]; then

--- a/src/slurm-bins/bin/slurmd
+++ b/src/slurm-bins/bin/slurmd
@@ -11,11 +11,12 @@ fi
 
 
 . "$SNAP/utilities/common-utilities"
-export SLURM_CONF=$SNAP_COMMON/etc/slurm/slurm.conf
-export SLURMD_LOG=$SNAP_COMMON/var/log/slurm/slurmd.log
-
+export SLURM_CONF="$SNAP_COMMON/etc/slurm/slurm.conf"
+export SLURMD_LOG="$SNAP_COMMON/var/log/slurm/slurmd.log"
+#export SLURMCTLD_HOSTNAME="$SNAP_COMMON/slurmctld_hostname"
 
 # Start slurmd only if we have a config file
+#if [ ! -f $SLURM_CONF ] && [ ! -f $SLURMCTLD_HOSTNAME ]; then
 if ! [[ -f $SLURM_CONF ]]; then
     pprint "No slurm conf, cannot start process.";
     exit -1
@@ -24,8 +25,24 @@ else
 fi
 
 pprint "Starting SLURMD";
+
+#if [ ! -f $SLURMCTLD_HOSTNAME ]; then
+#    exec "$SNAP/slurm-bins/slurmd" \
+#         "-f" "$SLURM_CONF" \
+#         "-d" "$SNAP/slurm-bins/slurmstepd" \
+#         "-L" "$SLURMD_LOG" \
+#         "-D" "$@"
+#else
+#    slurmctld=$(cat $SLURMCTLD_HOSTNAME)
+#    exec "$SNAP/slurm-bins/slurmd" \
+#         "-f" "$SLURM_CONF" \
+#         "-d" "$SNAP/slurm-bins/slurmstepd" \
+#         "-L" "$SLURMD_LOG" \
+#         "-D" "$@"
+#fi
+
 exec "$SNAP/slurm-bins/slurmd" \
-    "-f" "$SLURM_CONF" \
-    "-d" "$SNAP/slurm-bins/slurmstepd" \
-    "-L" "$SLURMD_LOG" \
-    "-D" "$@"
+     "-f" "$SLURM_CONF" \
+     "-d" "$SNAP/slurm-bins/slurmstepd" \
+     "-L" "$SLURMD_LOG" \
+     "-D" "$@"

--- a/src/slurm-bins/bin/slurmd
+++ b/src/slurm-bins/bin/slurmd
@@ -13,11 +13,11 @@ fi
 . "$SNAP/utilities/common-utilities"
 export SLURM_CONF="$SNAP_COMMON/etc/slurm/slurm.conf"
 export SLURMD_LOG="$SNAP_COMMON/var/log/slurm/slurmd.log"
-#export SLURMCTLD_HOSTNAME="$SNAP_COMMON/slurmctld_hostname"
+export SLURMCTLD_HOSTNAME="$SNAP_COMMON/slurmctld_hostname"
 
 # Start slurmd only if we have a config file
-#if [ ! -f $SLURM_CONF ] && [ ! -f $SLURMCTLD_HOSTNAME ]; then
-if ! [[ -f $SLURM_CONF ]]; then
+if [ ! -f $SLURM_CONF ] && [ ! -f $SLURMCTLD_HOSTNAME ]; then
+#if ! [[ -f $SLURM_CONF ]]; then
     pprint "No slurm conf, cannot start process.";
     exit -1
 else
@@ -26,23 +26,24 @@ fi
 
 pprint "Starting SLURMD";
 
-#if [ ! -f $SLURMCTLD_HOSTNAME ]; then
-#    exec "$SNAP/slurm-bins/slurmd" \
-#         "-f" "$SLURM_CONF" \
-#         "-d" "$SNAP/slurm-bins/slurmstepd" \
-#         "-L" "$SLURMD_LOG" \
-#         "-D" "$@"
-#else
-#    slurmctld=$(cat $SLURMCTLD_HOSTNAME)
-#    exec "$SNAP/slurm-bins/slurmd" \
-#         "-f" "$SLURM_CONF" \
-#         "-d" "$SNAP/slurm-bins/slurmstepd" \
-#         "-L" "$SLURMD_LOG" \
-#         "-D" "$@"
-#fi
+if [ ! -f $SLURMCTLD_HOSTNAME ]; then
+    exec "$SNAP/slurm-bins/slurmd" \
+         "-f" "$SLURM_CONF" \
+         "-d" "$SNAP/slurm-bins/slurmstepd" \
+         "-L" "$SLURMD_LOG" \
+         "-D" "$@"
+else
+    slurmctld=$(cat $SLURMCTLD_HOSTNAME)
+    exec "$SNAP/slurm-bins/slurmd" \
+	 "--conf-server" $slurmctld \
+         "-f" "$SLURM_CONF" \
+         "-d" "$SNAP/slurm-bins/slurmstepd" \
+         "-L" "$SLURMD_LOG" \
+         "-D" "$@"
+fi
 
-exec "$SNAP/slurm-bins/slurmd" \
-     "-f" "$SLURM_CONF" \
-     "-d" "$SNAP/slurm-bins/slurmstepd" \
-     "-L" "$SLURMD_LOG" \
-     "-D" "$@"
+#exec "$SNAP/slurm-bins/slurmd" \
+#     "-f" "$SLURM_CONF" \
+#     "-d" "$SNAP/slurm-bins/slurmstepd" \
+#     "-L" "$SLURMD_LOG" \
+##     "-D" "$@"

--- a/src/slurm-bins/bin/slurmd
+++ b/src/slurm-bins/bin/slurmd
@@ -41,9 +41,3 @@ else
          "-L" "$SLURMD_LOG" \
          "-D" "$@"
 fi
-
-#exec "$SNAP/slurm-bins/slurmd" \
-#     "-f" "$SLURM_CONF" \
-#     "-d" "$SNAP/slurm-bins/slurmstepd" \
-#     "-L" "$SLURMD_LOG" \
-##     "-D" "$@"

--- a/src/slurm-configurator/templates/slurm.conf.tmpl
+++ b/src/slurm-configurator/templates/slurm.conf.tmpl
@@ -11,8 +11,6 @@ SlurmdUser="root"
 AuthType="auth/munge"
 AuthInfo="socket=/tmp/munged.socket.2"
 
-DefaultStorageType=filetxt
-
 
 JobAcctGatherType="jobacct_gather/linux"
 JobAcctGatherFrequency=30


### PR DESCRIPTION
Changes to facilitate configless slurm operation.

* restart-condition -> never for all slurm daemons
The restart condition was previously set to on-failure which was causing the daemons to restart causing issues in other areas of slurm operation.
* Upgrade slurm to 20.11.3
Pick up fixes for configless issues in the latest version of slurm .
* Correctly handle setting and reading the munge key.
The munge key was previously being handled incorrectly. These changes encode and decode the munge key to base64, enabling us to later handle it as a string.
* Added snap config for `slurmctld.hostname`
Setting this values forces slurmd to use the `--conf-server` argument and enables configless operation mode.