### PR TITLE
CI: build snap using ubuntu 18.04

### DIFF
--- a/.github/workflows/release_edge.yaml
+++ b/.github/workflows/release_edge.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-snap:
     name: "Build the slurm snap"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-18.04"
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Our CI does not work with Ubuntu 20.04, see https://github.com/samuelmeuli/action-snapcraft/pull/23 